### PR TITLE
README.md tweaks: C++11 initialision, Markdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ pgi is a header only library built on top of [libpqxx](https://github.com/jtv/li
 
 ## Example
 
-```
+```cxx
     DatabaseWorker dbw("database_config.yaml");
 
-    std::map<std::string, double> double_cols;
-    double_cols["test_double1"] = 1.1;
-    
-    std::map<std::string, std::string> string_cols;
+    std::map<std::string, double> double_cols = {{"test_double", 1.1}};
+
+    std::map<std::string, std::string> string_cols = {
+        {"test_string", "Hello world!"}
+    }
     string_cols["test_string"] = "Hello world!";
-    
+
     std::map<std::string, time_point_t> time_cols;
     time_cols["time"] = tp;
-    
+
     dbw.insert_from_maps("public.test_table", double_cols, string_cols, time_cols);
     dbw.print("public.test_table");
 ```
@@ -27,9 +28,9 @@ pgi is a header only library built on top of [libpqxx](https://github.com/jtv/li
 
 ## Installation
 
-Installation is done using cmake. At the root of the source directory, run 
+Installation is done using cmake. At the root of the source directory, run
 
-```
+```sh
 mkdir build && cd build && cmake .. && make install
 ```
 
@@ -44,7 +45,7 @@ add_executable(main main.cpp)
 target_link_libraries(main pgi)
 ```
 
-2. Create a config file with yaml format. An example is given in [config/database_config.yaml](example/config/database_config.yaml). See [config file fields](#configuration-file-fields) for details.
+2. Create a config file with yaml format. An example is given in [config/database\_config.yaml](example/config/database_config.yaml). See [config\ file\ fields](#configuration-file-fields) for details.
 
 3. Include <pgi.hpp>
 
@@ -52,20 +53,23 @@ target_link_libraries(main pgi)
 
 5. Use DatabaseWorker methods. For example, insert columns from multiple std::map and print the content of the table :
 
-```
+```cxx
     DatabaseWorker dbw(
         pgi_test::pgi_config_dir + "database_config.yaml", pgi_test::pgi_config_dir + "database_config_out.yaml");
 
     // Most general method to insert a row
-    std::map<std::string, double> double_cols;
-    double_cols["test_double1"] = 1.1;
-    double_cols["test_double2"] = 2.2;
-    double_cols["test_double3"] = 3.3;
-    std::map<std::string, std::string> string_cols;
-    string_cols["test_string"] = "Hello world!";
-    std::map<std::string, time_point_t> time_cols;
-    time_cols["time"] = tp;
-    time_cols["time2"] = tp - 50s;
+    std::map<std::string, double> double_cols = {
+        {"test_double1", 1.1},
+        {"test_double2", 2.2},
+        {"test_double3", 3.3},
+    };
+    std::map<std::string, std::string> string_cols = {
+        {"test_string", "Hello world!"}
+    };
+    std::map<std::string, time_point_t> time_cols = {
+        {"time", tp},
+        {"time2", tp - 50s},
+    };
     dbw.insert_from_maps("public.test_table3", double_cols, string_cols, time_cols);
     dbw.insert_from_maps("public.test_table3", double_cols, string_cols, time_cols);
     dbw.insert_from_maps("public.test_table3", double_cols, string_cols, time_cols);
@@ -78,7 +82,7 @@ A minimal working environment (for the sake of example + continuous deployment) 
 
 ```./run_ci.sh```
 
-Will end with output :  
+Will end with output :
 
 ```
 test_double1 |test_double2 |test_double3 |time                    |test_string  |time2                   |
@@ -88,10 +92,10 @@ test_double1 |test_double2 |test_double3 |time                    |test_string  
 
 ```
 
-## Configuration file fields 
+## Configuration file fields
 
-+ connection : have to contain all the fields to establish database connection. Key/Values will be parsed to the connection string. See postgres documentation for the connection string [here](https://www.postgresql.org/docs/12/libpq-connect.html#LIBPQ-CONNSTRING). 
++ connection : have to contain all the fields to establish database connection. Key/Values will be parsed to the connection string. See postgres documentation for the connection string [here](https://www.postgresql.org/docs/12/libpq-connect.html#LIBPQ-CONNSTRING).
 
-+ [tables] : list tables to explore at the construction of DatabaseWorker 
++ [tables] : list tables to explore at the construction of DatabaseWorker
 
-+ [field_length_mapping] : configure the length of the printed column according to postgres type  
++ [field_length_mapping] : configure the length of the printed column according to postgres type


### PR DESCRIPTION
Suggesting a few cosmetic changes to the README.  The changes require C++11 as the minimum, but I hope this won't be a problem since the library depends on libpqxx which currently requires C++17 or better.

Most of the tweaks are about the Markdown syntax:
* Use C++11 initialisation syntax for those `std::map`s.  Much nicer.
* Mark code blocks as being in specific languages, where the choice is clear.  May enable syntax highlighting, depending on the renderer.
* Remove trailing whitespace.
* Escape underscores that are not meant to denote italics.

I found most of the Markdown gotchas by running `mdl`, a Markdown lint checker.